### PR TITLE
Add startPoint option to control where initial words get placed

### DIFF
--- a/d3.layout.cloud.js
+++ b/d3.layout.cloud.js
@@ -3,6 +3,7 @@
 (function(exports) {
   function cloud() {
     var size = [256, 256],
+        startPoint = null,
         text = cloudText,
         font = cloudFont,
         fontSize = cloudFontSize,
@@ -46,8 +47,13 @@
             d;
         while (+new Date - start < timeInterval && ++i < n && timer) {
           d = data[i];
-          d.x = (size[0] * (Math.random() + .5)) >> 1;
-          d.y = (size[1] * (Math.random() + .5)) >> 1;
+          if (startPoint) {
+            d.x = startPoint[0];
+            d.y = startPoint[1];
+          } else {
+            d.x = (size[0] * (Math.random() + .5)) >> 1;
+            d.y = (size[1] * (Math.random() + .5)) >> 1;
+          }
           cloudSprite(d, data, i);
           if (place(board, d, bounds)) {
             tags.push(d);
@@ -139,6 +145,12 @@
     cloud.size = function(x) {
       if (!arguments.length) return size;
       size = [+x[0], +x[1]];
+      return cloud;
+    };
+
+    cloud.startPoint = function(x) {
+      if (!arguments.length) return startPoint;
+      startPoint = [+x[0], +x[1]];
       return cloud;
     };
 


### PR DESCRIPTION
This adds the ability to control the starting position ([x,y] array) for the initial word/term being placed in the word cloud and can be used like so:

```
var width = 600;
var height = 300;
d3.layout.cloud().size([width, height])
          .startPoint([width/2.0, height/2.0])
...
```

which would ensure the first term is placed at the centre of the cloud. The startPoint can be any x,y position, however.

The parameter name could be something better or more descriptive, but the idea is there.
