### PR TITLE
Add configure options for initializing the word position

### DIFF
--- a/d3.layout.cloud.js
+++ b/d3.layout.cloud.js
@@ -11,7 +11,7 @@
         rotate = cloudRotate,
         padding = cloudPadding,
         spiral = archimedeanSpiral,
-        initPos = centerPointPos,
+        initPos = centerAreaPos,
         words = [],
         timeInterval = Infinity,
         event = d3.dispatch("word", "end"),

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -12,7 +12,6 @@
         "than", "this"].map(function(d) {
         return {text: d, size: 10 + Math.random() * 90};
       }))
-      .initPos("point")
       .padding(5)
       .rotate(function() { return ~~(Math.random() * 2) * 90; })
       .font("Impact")


### PR DESCRIPTION
This patch add the support for gathering word in the center instead of placing them loosely. The difference will be obvious with relative few words in small font.

It is part of my project to outline a hidden symbol with word cloud. See [screenshot](https://f.cloud.github.com/assets/5027771/1444857/367c5b30-4213-11e3-8275-99db7c958791.png)

NOTE: It may downgrade the performance as all the spirals are starting from the same points.
