### PR TITLE
add a call to allow specification of RNG function

### DIFF
--- a/d3.layout.cloud.js
+++ b/d3.layout.cloud.js
@@ -11,6 +11,7 @@
         rotate = cloudRotate,
         padding = cloudPadding,
         spiral = archimedeanSpiral,
+        random = Math.random,
         words = [],
         timeInterval = Infinity,
         event = d3.dispatch("word", "end"),
@@ -45,8 +46,8 @@
             d;
         while (+new Date - start < timeInterval && ++i < n && timer) {
           d = data[i];
-          d.x = (size[0] * (Math.random() + .5)) >> 1;
-          d.y = (size[1] * (Math.random() + .5)) >> 1;
+          d.x = (size[0] * (random() + .5)) >> 1;
+          d.y = (size[1] * (random() + .5)) >> 1;
           cloudSprite(d, data, i);
           if (d.hasText && place(board, d, bounds)) {
             tags.push(d);
@@ -85,7 +86,7 @@
           startY = tag.y,
           maxDelta = Math.sqrt(size[0] * size[0] + size[1] * size[1]),
           s = spiral(size),
-          dt = Math.random() < .5 ? 1 : -1,
+          dt = random() < .5 ? 1 : -1,
           t = -dt,
           dxdy,
           dx,
@@ -177,6 +178,12 @@
       return cloud;
     };
 
+    cloud.random = function(x) {
+      if (!arguments.length) return random;
+      random = d3.functor(x);
+      return cloud;
+    };
+
     cloud.fontSize = function(x) {
       if (!arguments.length) return fontSize;
       fontSize = d3.functor(x);
@@ -209,7 +216,7 @@
   }
 
   function cloudRotate() {
-    return (~~(Math.random() * 6) - 3) * 30;
+    return (~~(random() * 6) - 3) * 30;
   }
 
   function cloudPadding() {


### PR DESCRIPTION
I've added a cloud.random(f) call that allows one to supply an alternative random number generator function to the layout engine.  If you supply a function returning a constant value, you get behavior like https://github.com/jasondavies/d3-cloud/pull/14.  A more interesting case to supply a seeded RNG so that you can get the visual effect of a random cloud but a repeatable layout by either seeding with a constant or a value computed simply from the tag field.  The default behavior is to use Math.random() as before.
Example1: 
 cloud.random(function() { return 0.5; })
Example2:
 var myrng = SeedRandom.rng("myseed");
 cloud.random(function() { return myrng.random(); } )