### PR TITLE
making canvas optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "main": "index.js",
   "dependencies": {
-    "d3": "3.x",
+    "d3": "3.x"
+  },
+  "optionalDependencies": {
     "canvas": "1.2.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "optionalDependencies": {
     "canvas": "1.2.x"
+  },
+  "scripts": {
+    "postinstall": "[ -d  node_modules/canvas ] && echo \"Installed. \" || echo \"NOTE: Canvas it is not currently installed, if you need server side render you need to install it and its dependancies.\" #CHECKING FOR CANVAS"
   }
 }


### PR DESCRIPTION
canvas is not installable unless you have a
linux/mac machine with cairo, which is a non-trivial task