### PR TITLE
only require canvas when not in the browser

### DIFF
--- a/d3.layout.cloud.js
+++ b/d3.layout.cloud.js
@@ -372,6 +372,7 @@ function cloud(d3) {
     canvas.height = ch / ratio;
   } else {
     // Attempt to use node-canvas.
+    var Canvas = require('Canvas');
     canvas = new Canvas(cw << 5, ch);
   }
 

--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@ var globals = {};
 
 // stash globals
 if ("d3" in global) globals.d3 = global.d3;
-if ("Canvas" in global) globals.Canvas = global.Canvas;
 global.d3 = require("d3");
-global.Canvas = require("canvas");
 
 require("./d3.layout.cloud");
 module.exports = d3.layout.cloud;
@@ -12,5 +10,3 @@ module.exports = d3.layout.cloud;
 // restore globals
 if ("d3" in globals) global.d3 = globals.d3;
 else delete global.d3;
-if ("Canvas" in globals) global.Canvas = globals.Canvas;
-else delete global.Canvas;


### PR DESCRIPTION
Hey @jasondavies, thanks for the cool lib!

This PR ensures that the `require('canvas')` statement is only fired when the library is being used in node (not in the browser). This will play nicely with #72, and if these both get merged the library should work seamlessly in client-side environments.

This fixes errors that I've been seeing while integrating the library into [lightning-viz/lighting](/lightning-viz/lightning)