### PR TITLE
pass the whole words array to mapping functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,14 +36,14 @@ module.exports = function() {
         n = words.length,
         i = -1,
         tags = [],
-        data = words.map(function(d, i) {
-          d.text = text.call(this, d, i);
-          d.font = font.call(this, d, i);
-          d.style = fontStyle.call(this, d, i);
-          d.weight = fontWeight.call(this, d, i);
-          d.rotate = rotate.call(this, d, i);
-          d.size = ~~fontSize.call(this, d, i);
-          d.padding = padding.call(this, d, i);
+        data = words.map(function(d, i, words) {
+          d.text = text.call(this, d, i, words);
+          d.font = font.call(this, d, i, words);
+          d.style = fontStyle.call(this, d, i, words);
+          d.weight = fontWeight.call(this, d, i, words);
+          d.rotate = rotate.call(this, d, i, words);
+          d.size = ~~fontSize.call(this, d, i, words);
+          d.padding = padding.call(this, d, i, words);
           return d;
         }).sort(function(a, b) { return b.size - a.size; });
 


### PR DESCRIPTION
I would like to pass a custom fontSize mapper like this:

```js
function fontSizeMapper (word, idx, words) {
  const max = 100;
  const min = 10;
  const wordSize = words.map(w => w.size);
  const minSize = Math.min(...wordSize);
  const maxSize = Math.max(...wordSize);
  return min + (max - min) * (word.size - minSize) / (maxSize - minSize);
};
```

It's a normalization of font sizes, which requires to know the min and max value of word counts.