### PR TITLE
Words desired position

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ function(d) { return d.text; }
 
 A constant may be specified instead of a function.
 
+<a name="position" href="#position">#</a> <b>position</b>([<i>position</i>])
+
+If specified, sets the **position** accessor function, which indicates the desired
+x, y position for each word (must be between 0 and 1).  If not specified, returns the current position accessor
+function, which defaults to:
+
+```js
+function() { return {x: Math.random(), y: Math.random()}; }
+```
+
+A constant may be specified instead of a function.
+
 <a name="spiral" href="#spiral">#</a> <b>spiral</b>([<i>spiral</i>])
 
 If specified, sets the current type of spiral used for positioning words.  This

--- a/build/d3.layout.cloud.js
+++ b/build/d3.layout.cloud.js
@@ -11,6 +11,7 @@ var cloudRadians = Math.PI / 180,
 module.exports = function() {
   var size = [256, 256],
       text = cloudText,
+      position = cloudPosition,
       font = cloudFont,
       fontSize = cloudFontSize,
       fontStyle = cloudFontNormal,
@@ -58,8 +59,9 @@ module.exports = function() {
       var start = Date.now();
       while (Date.now() - start < timeInterval && ++i < n && timer) {
         var d = data[i];
-        d.x = (size[0] * (random() + .5)) >> 1;
-        d.y = (size[1] * (random() + .5)) >> 1;
+        var p = position(d);
+        d.x = (size[0] * (p.x + .5)) >> 1;
+        d.y = (size[1] * (p.y + .5)) >> 1;
         cloudSprite(contextAndRatio, d, data, i);
         if (d.hasText && place(board, d, bounds)) {
           tags.push(d);
@@ -181,6 +183,10 @@ module.exports = function() {
     return arguments.length ? (text = functor(_), cloud) : text;
   };
 
+  cloud.position = function(_) {
+      return arguments.length ? (position = functor(_), cloud) : position;
+  };
+
   cloud.spiral = function(_) {
     return arguments.length ? (spiral = spirals[_] || _, cloud) : spiral;
   };
@@ -207,6 +213,10 @@ module.exports = function() {
 
 function cloudText(d) {
   return d.text;
+}
+
+function cloudPosition() {
+  return {x: Math.random(), y: Math.random()};
 }
 
 function cloudFont() {
@@ -400,11 +410,11 @@ var spirals = {
 };
 
 },{"d3-dispatch":2}],2:[function(require,module,exports){
-// https://d3js.org/d3-dispatch/ Version 1.0.2. Copyright 2016 Mike Bostock.
+// https://d3js.org/d3-dispatch/ Version 1.0.3. Copyright 2017 Mike Bostock.
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
-  typeof define === 'function' && define.amd ? define(['exports'], factory) :
-  (factory((global.d3 = global.d3 || {})));
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.d3 = global.d3 || {})));
 }(this, (function (exports) { 'use strict';
 
 var noop = {value: function() {}};

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var cloudRadians = Math.PI / 180,
 module.exports = function() {
   var size = [256, 256],
       text = cloudText,
+      position = cloudPosition,
       font = cloudFont,
       fontSize = cloudFontSize,
       fontStyle = cloudFontNormal,
@@ -57,8 +58,9 @@ module.exports = function() {
       var start = Date.now();
       while (Date.now() - start < timeInterval && ++i < n && timer) {
         var d = data[i];
-        d.x = (size[0] * (random() + .5)) >> 1;
-        d.y = (size[1] * (random() + .5)) >> 1;
+        var p = position(d);
+        d.x = (size[0] * (p.x + .5)) >> 1;
+        d.y = (size[1] * (p.y + .5)) >> 1;
         cloudSprite(contextAndRatio, d, data, i);
         if (d.hasText && place(board, d, bounds)) {
           tags.push(d);
@@ -180,6 +182,10 @@ module.exports = function() {
     return arguments.length ? (text = functor(_), cloud) : text;
   };
 
+  cloud.position = function(_) {
+      return arguments.length ? (position = functor(_), cloud) : position;
+  };
+
   cloud.spiral = function(_) {
     return arguments.length ? (spiral = spirals[_] || _, cloud) : spiral;
   };
@@ -206,6 +212,10 @@ module.exports = function() {
 
 function cloudText(d) {
   return d.text;
+}
+
+function cloudPosition() {
+  return {x: Math.random(), y: Math.random()};
 }
 
 function cloudFont() {


### PR DESCRIPTION
Hi,

For a semantic analysis application I had to be able to manually set words' desired position to be able to see semantic groups of words... So I've added a `.position()` setter to the `cloud` class.
I think this little feature could be useful to other people...

FYI the words position could be "easily" precomputed by combining a word2vec transformation with a manifold algorithm such as [t-SNE](http://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html)

Regards,