### PR TITLE
Create predictive seed in random

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ module.exports = function() {
       var start = Date.now();
       while (Date.now() - start < timeInterval && ++i < n && timer) {
         var d = data[i];
-        d.x = (size[0] * (random() + .5)) >> 1;
-        d.y = (size[1] * (random() + .5)) >> 1;
+        d.x = (size[0] * (random(d.text) + .5)) >> 1;
+        d.y = (size[1] * (random(d.text) + .5)) >> 1;
         cloudSprite(contextAndRatio, d, data, i);
         if (d.hasText && place(board, d, bounds)) {
           tags.push(d);


### PR DESCRIPTION
## Why
I need consistent and arbitrary placement of words. `d3cloud.random` determines placement, and returning a fixed number creates visual patterns. While returning a random number creates inconsistent word cloud generation.
  
## What
Pass the word to `d3cloud.random` so the word can be hashed to determine placement

## Use it somehow similar to this
```js
d3cloud.random((dText = '') => Number(`0.${Math.abs(murmur2(dText))}`))
```

### Notes
`Math.random` is used when `d3cloud.random` is not specified. In this PR it is receiving `d.text` as an argument, but it it doesn't accept arguments, so it's benign. If anyone wants to argue this is bad I could maybe fix it.