### PR TITLE
Add support for storybook.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "sourceType": "unambiguous",
+  "presets": [
+    "@babel/preset-env"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 npm-debug.log
+/.node-version
+/storybook-static

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,8 @@
+import '@storybook/addon-actions/register';
+import '@storybook/addon-events/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-links/register';
+import '@storybook/addon-notes/register';
+import '@storybook/addon-options/register';
+import '@storybook/addon-storysource/register';
+import '@storybook/addon-viewport/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,4 @@
+import { configure } from '@storybook/html';
+
+// automatically import all files ending in *.stories.js
+configure(require.context('../stories', true, /\.stories\.js$/), module);

--- a/.storybook/presets.js
+++ b/.storybook/presets.js
@@ -1,0 +1,1 @@
+module.exports = ['@storybook/addon-docs/html/preset'];

--- a/package.json
+++ b/package.json
@@ -23,12 +23,38 @@
     "url": "https://github.com/jasondavies/d3-cloud.git"
   },
   "scripts": {
-    "build": "mkdir -p build && browserify --standalone d3.layout.cloud index.js > build/d3.layout.cloud.js"
+    "build": "mkdir -p build && browserify --standalone d3.layout.cloud index.js > build/d3.layout.cloud.js",
+    "storybook": "start-storybook",
+    "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "d3-dispatch": "^1.0.3"
+    "d3-dispatch": "^1.0.3",
+    "canvas": "^1.2.3",
+    "d3": "3.x"
   },
   "devDependencies": {
-    "browserify": "^11.2.0"
+    "@babel/core": "^7.6.4",
+    "@storybook/addon-actions": "5.2.5",
+    "@storybook/addon-centered": "5.2.5",
+    "@storybook/addon-docs": "5.2.5",
+    "@storybook/addon-events": "5.2.5",
+    "@storybook/addon-knobs": "5.2.5",
+    "@storybook/addon-links": "5.2.5",
+    "@storybook/addon-notes": "5.2.5",
+    "@storybook/addon-options": "5.2.5",
+    "@storybook/addon-storyshots": "5.2.5",
+    "@storybook/addon-storysource": "5.2.5",
+    "@storybook/addon-viewport": "5.2.5",
+    "@storybook/addons": "5.2.5",
+    "@storybook/client-api": "5.2.5",
+    "@storybook/core": "5.2.5",
+    "@storybook/core-events": "5.2.5",
+    "@storybook/html": "5.2.5",
+    "@storybook/source-loader": "5.2.5",
+    "babel-loader": "^8.0.6",
+    "browserify": "^11.2.0",
+    "eventemitter3": "^4.0.0",
+    "format-json": "^1.0.3",
+    "global": "^4.3.2"
   }
 }

--- a/stories/slanted.stories.js
+++ b/stories/slanted.stories.js
@@ -1,0 +1,47 @@
+import {action} from '@storybook/addon-actions';
+import * as samples from './support/text_samples'
+import {cloudTest} from "./support/cloud_test";
+import {
+    array,
+    boolean,
+    button,
+    color,
+    date,
+    select,
+    withKnobs,
+    text,
+    number,
+} from '@storybook/addon-knobs';
+
+export default {
+    title: 'Word Cloud | Slanted',
+    decorators: [withKnobs],
+};
+
+const options = {angle: 45};
+
+export const words = () => {
+    return cloudTest(samples.WORDS, options);
+};
+
+export const phrase = () => {
+    return cloudTest(samples.SENTENCE, options);
+};
+
+export const loremShort = () => {
+    return cloudTest(samples.LOREM_SHORT, options);
+};
+
+export const loremLong = () => {
+    return cloudTest(samples.LOREM_LONG, options);
+};
+
+export const ownText = () => {
+    const words = text(
+        'Words',
+        `You can, put your own words in here. Separate them by space`);
+    return cloudTest(words.split(' '), options);
+};
+
+
+

--- a/stories/support/cloud_test.js
+++ b/stories/support/cloud_test.js
@@ -1,0 +1,59 @@
+
+const d3 = require("d3"),
+    cloud = require("../../index");
+
+export function cloudTest(words, options) {
+
+    const div = document.createElement('div');
+    div.setAttribute("id", 'cloudCanvas');
+    div.setAttribute("style", "display: block; width: 500px; height: 500px; background: #eee");
+
+
+    const fill = d3.scale.category20();
+
+    const layout = cloud()
+        .size([500, 500])
+        .words(words.map(function (d) {
+            return {text: d, size: 10 + Math.random() * 90, test: "haha"};
+        }))
+        .padding(5)
+        .rotate(function () {
+            return ~~(Math.random() * (180/options.angle)) * options.angle;
+        })
+        .font("Impact")
+        .fontSize(function (d) {
+            return d.size;
+        })
+        .on("end", draw);
+
+    function draw(words) {
+        d3.select('div#cloudCanvas').append("svg")
+            .attr("width", layout.size()[0])
+            .attr("height", layout.size()[1])
+            .append("g")
+            .attr("transform", "translate(" + layout.size()[0] / 2 + "," + layout.size()[1] / 2 + ")")
+            .selectAll("text")
+            .data(words)
+            .enter().append("text")
+            .style("font-size", function (d) {
+                return d.size + "px";
+            })
+            .style("font-family", "Impact")
+            .style("fill", function (d, i) {
+                return fill(i);
+            })
+            .attr("text-anchor", "middle")
+            .attr("transform", function (d) {
+                return "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")";
+            })
+            .text(function (d) {
+                return d.text;
+            });
+    }
+
+    setTimeout(() => {
+        layout.start()
+    }, 5);
+
+    return div;
+}

--- a/stories/support/text_samples.js
+++ b/stories/support/text_samples.js
@@ -1,0 +1,36 @@
+export const WORDS = [
+    "Hello", "world", "normally", "you", "want", "more", "words",
+    "than", "this"];
+export const SENTENCE = 'The quick brown fox jumps over the lazy dog'.split(' ');
+export const LOREM_SHORT = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod 
+    tempor incididunt ut labore et dolore magna aliqua. Orci sagittis eu volutpat odio facilisis mauris. 
+    In fermentum posuere urna nec tincidunt praesent semper feugiat. A pellentesque sit amet porttitor eget 
+    dolor morbi. Quisque id diam vel quam elementum pulvinar etiam non. Volutpat ac tincidunt vitae semper quis 
+    lectus. At elementum eu facilisis sed. Consectetur adipiscing elit duis tristique 
+    sollicitudin. `.split(' ');
+
+export const LOREM_LONG = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do 
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Orci sagittis eu volutpat odio facilisis mauris. 
+    In fermentum posuere urna nec tincidunt praesent semper feugiat. A pellentesque sit amet porttitor eget 
+    dolor morbi. Quisque id diam vel quam elementum pulvinar etiam non. Volutpat ac tincidunt vitae semper quis 
+    lectus. At elementum eu facilisis sed. Consectetur adipiscing elit duis tristique sollicitudin. 
+    Augue eget arcu dictum varius duis. Cras adipiscing enim eu turpis egestas pretium aenean pharetra 
+    magna. Enim facilisis gravida neque convallis a cras semper auctor neque. Praesent semper feugiat 
+    nibh sed pulvinar. Sed risus pretium quam vulputate dignissim suspendisse in. Varius quam quisque id diam.
+    
+    Et malesuada fames ac turpis egestas sed tempus urna. Vitae sapien pellentesque habitant morbi tristique.
+     Enim facilisis gravida neque convallis a. Purus sit amet volutpat consequat mauris nunc. Ut venenatis tellus 
+     in metus vulputate eu. Ullamcorper malesuada proin libero nunc consequat interdum varius. Eget nunc scelerisque 
+     viverra mauris in aliquam sem fringilla ut. Montes nascetur ridiculus mus mauris vitae. Sapien nec sagittis 
+     aliquam malesuada bibendum. Consectetur purus ut faucibus pulvinar elementum integer enim neque. 
+     Tellus id interdum velit laoreet id donec ultrices tincidunt arcu. Dui accumsan sit amet nulla facilisi.
+     
+     Suspendisse ultrices gravida dictum fusce ut placerat orci nulla. Ultricies integer quis auctor elit 
+     sed vulputate. Est lorem ipsum dolor sit amet consectetur adipiscing elit. Pellentesque massa placerat 
+     duis ultricies lacus sed turpis. Augue lacus viverra vitae congue eu consequat ac. Praesent elementum 
+     facilisis leo vel fringilla est ullamcorper eget. Id faucibus nisl tincidunt eget. Platea dictumst 
+     vestibulum rhoncus est pellentesque. Rhoncus mattis rhoncus urna neque. Scelerisque viverra mauris 
+     in aliquam sem fringilla. Tortor vitae purus faucibus ornare suspendisse sed nisi lacus. 
+     Nam libero justo laoreet sit amet cursus. Eget magna fermentum iaculis eu non. Tellus id 
+     interdum velit laoreet id donec. Viverra ipsum nunc aliquet bibendum enim facilisis 
+     gravida. `.split(' ');

--- a/stories/upright.stories.js
+++ b/stories/upright.stories.js
@@ -1,0 +1,37 @@
+import {action} from '@storybook/addon-actions';
+import * as samples from './support/text_samples'
+import {cloudTest} from "./support/cloud_test";
+import {
+    array,
+    boolean,
+    button,
+    color,
+    date,
+    select,
+    withKnobs,
+    text,
+    number,
+} from '@storybook/addon-knobs';
+
+export default {
+    title: 'Word Cloud | Upright',
+    decorators: [withKnobs],
+};
+
+const options = {angle: 90};
+
+export const words = () => {
+    return cloudTest(samples.WORDS, options);
+};
+
+export const phrase = () => {
+    return cloudTest(samples.SENTENCE, options);
+};
+
+export const loremShort = () => {
+    return cloudTest(samples.LOREM_SHORT, options);
+};
+
+export const loremLong = () => {
+    return cloudTest(samples.LOREM_LONG, options);
+};


### PR DESCRIPTION
[Storybook.js](https://storybook.js.org) is a new radical way to develop web components.  I am planning to do some work on this component.  First my plan is to bring the development into the 20s.  

First step is the storybook.  The PR sets-up some scaffolding for the story book,  to check it out just run:

```
   npm install
   npm run story-book
```

It's also possible to build static sites out of story books.  Here is an example deployed via netlify.

https://confident-tereshkova-2a9fac.netlify.com/?path=/story/word-cloud-slanted--words

With Netlify you can speed-up PR acceptance,  by enabling auto deploys of submitted PR request to temp URL.




